### PR TITLE
FIX: typo (README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ### For running tests
 
-- Build alive. `cd scripts/verification && bash build.sh`
+- Build alive. `cd scripts/verifier && bash build.sh`
 - Enter the scripts folder
 - Install it as a package `pip3 install -e .`
 - Run each test module inside the `tests` folder. For example `python3 -m tests.openssl_usecase`


### PR DESCRIPTION
The project's README had an instruction which was probably outdated (a folder name is similar, but different)