### PR TITLE
verifier: install ninja before switching to alive

### DIFF
--- a/scripts/verifier/build.sh
+++ b/scripts/verifier/build.sh
@@ -4,6 +4,7 @@ mkdir -p build
 cd build
 cmake -GNinja -DLLVM_ENABLE_RTTI=ON -DLLVM_ENABLE_EH=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_RTTI=ON  -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_ENABLE_PROJECTS="llvm;clang" ../llvm
 cd ../../
+ninja; ninja install
 
 echo "Building alive"
 cd alive


### PR DESCRIPTION
the absence of the line was causing issues when running the verifier