### PR TITLE
fix: add watchdog to script requirements

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,2 +1,3 @@
 openai
 toml
+watchdog


### PR DESCRIPTION
In new installations, stuff failed because of it (I think)