### PR TITLE
fix: await shadow comparison, remove -o param in usecases case test

### DIFF
--- a/scripts/usecases/case.py
+++ b/scripts/usecases/case.py
@@ -467,7 +467,7 @@ class TestLLVMCompilableUseCase(LLVMCompilableUseCase):
         f.close()
         # lets call clang
         # use subprocess
-        ch = subprocess.run(["clang",  "-save-temps", "-o", "main.o", "main.cpp"], cwd=cwd)
+        ch = subprocess.run(["clang",  "-save-temps", "main.cpp"], cwd=cwd)
 
 
 class CMPResult:
@@ -505,7 +505,7 @@ if __name__ == '__main__':
         # changed_cource_code -> changed_compilable
         await t2
         await t1
-        modified, insrc_only, indst_only = uc.compare_shadows(shadow1, shadow2)
+        modified, insrc_only, indst_only = await uc.compare_shadows(shadow1, shadow2)
         print("Modified", modified)
 
 


### PR DESCRIPTION
while I was dabbling around the optimization, I found this: I think both these fixes are required for the test to run properly (`python -m usecases.case`), tell me if you agree